### PR TITLE
Improve code quality especially in Parser class

### DIFF
--- a/data/tasks.txt
+++ b/data/tasks.txt
@@ -1,1 +1,4 @@
 D | 1 | new task | Dec 20 2020 8:20 PM
+T | 0 | new task
+D | 0 | CS2103 week 5 | Dec 20 2020 8:20 PM
+E | 0 | lol | Dec 20 2020 8:20 PM

--- a/src/main/java/duke/Deadline.java
+++ b/src/main/java/duke/Deadline.java
@@ -2,8 +2,8 @@ package duke;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Objects;
 
 
 /**
@@ -21,13 +21,12 @@ public class Deadline extends Task {
      * Creates a Task with a deadline which has not been marked as done.
      *
      * @param description Details of what has to be done in the Task.
-     * @param date Date of the deadline of the Task.
-     * @param time Time of the deadline of the Task.
+     * @param dateTime Date and time of the deadline of the Task.
      */
-    public Deadline(String description, LocalDate date, LocalTime time) {
+    public Deadline(String description, LocalDateTime dateTime) {
         super(description);
-        this.date = date;
-        this.time = time;
+        this.date = dateTime.toLocalDate();
+        this.time = dateTime.toLocalTime();
     }
 
     /**
@@ -35,23 +34,12 @@ public class Deadline extends Task {
      *
      * @param description Details of what has to be done in the Task.
      * @param isDone Boolean value that indicates if the Task has been completed.
-     * @param date Date of the deadline of the Task.
-     * @param time Time of the deadline of the Task.
+     * @param dateTime Date and time of the deadline of the Task.
      */
-    public Deadline(String description, boolean isDone, LocalDate date, LocalTime time) {
+    public Deadline(String description, boolean isDone, LocalDateTime dateTime) {
         super(description, isDone);
-        this.date = date;
-        this.time = time;
-    }
-
-    /**
-     * Returns the hashcode of the Deadline.
-     *
-     * @return Hashcode of the Deadline.
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(date, time);
+        this.date = dateTime.toLocalDate();
+        this.time = dateTime.toLocalTime();
     }
 
     /**

--- a/src/main/java/duke/Event.java
+++ b/src/main/java/duke/Event.java
@@ -2,7 +2,7 @@ package duke;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 
@@ -22,13 +22,12 @@ public class Event extends Task {
      * Creates an Event which has not been marked as done.
      *
      * @param description Details of the Event.
-     * @param date Date of the occurrence of the Event.
-     * @param time Time of the occurrence of the Event.
+     * @param dateTime Date and time of the occurrence of the Event.
      */
-    public Event(String description, LocalDate date, LocalTime time) {
+    public Event(String description, LocalDateTime dateTime) {
         super(description);
-        this.date = date;
-        this.time = time;
+        this.date = dateTime.toLocalDate();
+        this.time = dateTime.toLocalTime();
     }
 
     /**
@@ -36,13 +35,12 @@ public class Event extends Task {
      *
      * @param description Details of the Event.
      * @param isDone Boolean value that indicates if the Task has been completed.
-     * @param date Date of the occurrence of the Event.
-     * @param time Time of the occurrence of the Event.
+     * @param dateTime Date and time of the occurrence of the Event.
      */
-    public Event(String description, boolean isDone, LocalDate date, LocalTime time) {
+    public Event(String description, boolean isDone, LocalDateTime dateTime) {
         super(description, isDone);
-        this.date = date;
-        this.time = time;
+        this.date = dateTime.toLocalDate();
+        this.time = dateTime.toLocalTime();
     }
 
     /**

--- a/src/test/java/ParserTest.java
+++ b/src/test/java/ParserTest.java
@@ -2,6 +2,7 @@ import duke.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,8 +16,7 @@ public class ParserTest {
         String fullTask = "D | 0 | Sample Task | Oct 12 2020 8:00 PM";
         Task actualTask = Parser.parseTask(fullTask);
         Task expectedTask = new Deadline("Sample Task", false,
-                LocalDate.of(2020, 10, 12),
-                LocalTime.of(20, 0));
+                LocalDateTime.of(2020, 10, 12, 20, 0));
         assertEquals(expectedTask.toDisplayString(), actualTask.toDisplayString());
     }
 
@@ -25,8 +25,7 @@ public class ParserTest {
         String fullTask = "E | 1 | Sample Event | Oct 12 2020 8:00 PM";
         Task actualTask = Parser.parseTask(fullTask);
         Task expectedTask = new Event("Sample Event", true,
-                LocalDate.of(2020, 10, 12),
-                LocalTime.of(20, 0));
+                LocalDateTime.of(2020, 10, 12, 20, 0));
         assertEquals(expectedTask.toDisplayString(), actualTask.toDisplayString());
     }
 


### PR DESCRIPTION
Shorten code for Parser class by abstracting the process of parsing deadlines, events and dates as functions. This would make the switch-case blocks much more readable.